### PR TITLE
Changed URL from aueb.eclass.gr to eclass.aueb.gr

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ pip3 install -r requirements.txt
 ```
 
 ##### Warning
-This code in it's current version is only used for public [eclass](https://aueb.eclass.gr) classes
+This code in it's current version is only used for public [eclass](https://eclass.aueb.gr) classes


### PR DESCRIPTION
The previous URL was incorrect, and the correct URL for the eclass platform at Athens University of Economics and Business (AUEB) is eclass.aueb.gr. Therefore, I updated the URL in the README to reflect the correct address.  :]